### PR TITLE
Fix VS2022 compiler error in D3D configurations

### DIFF
--- a/src/common/IvGraphics/D3D11/IvConstantTableD3D11.h
+++ b/src/common/IvGraphics/D3D11/IvConstantTableD3D11.h
@@ -18,6 +18,7 @@
 //-------------------------------------------------------------------------------
 #include <d3d11.h>
 #include <map>
+#include <string>
 
 #include "IvUniform.h"
 


### PR DESCRIPTION
Missing include `<string>` in `IvConstantTableD3D11.h` leads to compiler errors in
Visual Studio 2022 i.e. Microsoft C/C++ Optimizing Compiler Version 19.39.33520.