### PR TITLE
Fix VS2022 linker errors in OGL configurations

### DIFF
--- a/src/common/IvGraphics/IvGraphics.vcxproj
+++ b/src/common/IvGraphics/IvGraphics.vcxproj
@@ -109,6 +109,7 @@
     <Lib>
       <OutputFile>..\Libs\OGLRelease\IvGraphics.lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalDependencies>legacy_stdio_definitions.lib</AdditionalDependencies>
     </Lib>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -145,6 +146,7 @@ copy .\OGL\Iv*.h ..\Includes\OGL
     <Lib>
       <OutputFile>..\Libs\OGLDebug\IvGraphics.lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalDependencies>legacy_stdio_definitions.lib</AdditionalDependencies>
     </Lib>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
Building with Visual Studio 2022 gives linker errors for OGL configs

```
1>glfw3.lib(init.c.obj) : error LNK2019: unresolved external symbol
  __imp__vsnprintf referenced in function __glfwInputError
1>MSVCRT.lib(vsnprintf.obj) : error LNK2001: unresolved external
  symbol __imp__vsnprintf
1>glfw3.lib(context.c.obj) : error LNK2019: unresolved external symbol
  __imp__sscanf referenced in function _parseVersionString
1>MSVCRT.lib(vsnprintf.obj) : error LNK2001: unresolved external
  symbol __imp___vsnprintf
```

Visual Studio 2015’s breaking changes [1] moved these to `legacy_stdio_definitions.lib`.

Fix by adding this library as a dependency to IvGraphics project.

[1]: https://learn.microsoft.com/en-us/cpp/porting/visual-cpp-change-history-2003-2015?view=msvc-170&redirectedfrom=MSDN